### PR TITLE
Faster access into the RNG's mixSeed method

### DIFF
--- a/src/main/java/net/gegy1000/zoomlayer/CachingLayerAccess.java
+++ b/src/main/java/net/gegy1000/zoomlayer/CachingLayerAccess.java
@@ -5,7 +5,6 @@ package net.gegy1000.zoomlayer;
  *
  * @author SuperCoder79
  */
-public interface Shuffleable {
-
-	void shuffle();
+public interface CachingLayerAccess {
+	void skipInt();
 }

--- a/src/main/java/net/gegy1000/zoomlayer/Shuffleable.java
+++ b/src/main/java/net/gegy1000/zoomlayer/Shuffleable.java
@@ -1,0 +1,11 @@
+package net.gegy1000.zoomlayer;
+
+/**
+ * Provides an access to the layer's mixSeed command without the overhead of floorMod.
+ *
+ * @author SuperCoder79
+ */
+public interface Shuffleable {
+
+	void shuffle();
+}

--- a/src/main/java/net/gegy1000/zoomlayer/mixin/MixinCachingLayerContext.java
+++ b/src/main/java/net/gegy1000/zoomlayer/mixin/MixinCachingLayerContext.java
@@ -5,14 +5,21 @@ import net.gegy1000.zoomlayer.FastCachingLayerSampler;
 import net.minecraft.world.biome.layer.util.CachingLayerContext;
 import net.minecraft.world.biome.layer.util.CachingLayerSampler;
 import net.minecraft.world.biome.layer.util.LayerOperator;
+import net.minecraft.world.biome.source.SeedMixer;
+
+import net.gegy1000.zoomlayer.Shuffleable;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(CachingLayerContext.class)
-public class MixinCachingLayerContext {
+public class MixinCachingLayerContext implements Shuffleable {
+    @Shadow private long localSeed;
+    @Shadow @Final private long worldSeed;
     private ConcurrentLayerCache fastCache;
 
     @Inject(method = "<init>", at = @At("RETURN"))
@@ -48,5 +55,10 @@ public class MixinCachingLayerContext {
     @Overwrite
     public CachingLayerSampler createSampler(LayerOperator operator, CachingLayerSampler left, CachingLayerSampler right) {
         return new FastCachingLayerSampler(this.fastCache, operator);
+    }
+
+    @Override
+    public void shuffle() {
+        this.localSeed = SeedMixer.mixSeed(this.localSeed, this.worldSeed);
     }
 }

--- a/src/main/java/net/gegy1000/zoomlayer/mixin/MixinCachingLayerContext.java
+++ b/src/main/java/net/gegy1000/zoomlayer/mixin/MixinCachingLayerContext.java
@@ -7,7 +7,7 @@ import net.minecraft.world.biome.layer.util.CachingLayerSampler;
 import net.minecraft.world.biome.layer.util.LayerOperator;
 import net.minecraft.world.biome.source.SeedMixer;
 
-import net.gegy1000.zoomlayer.Shuffleable;
+import net.gegy1000.zoomlayer.CachingLayerAccess;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
@@ -17,7 +17,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(CachingLayerContext.class)
-public class MixinCachingLayerContext implements Shuffleable {
+public class MixinCachingLayerContext implements CachingLayerAccess {
     @Shadow private long localSeed;
     @Shadow @Final private long worldSeed;
     private ConcurrentLayerCache fastCache;
@@ -58,7 +58,7 @@ public class MixinCachingLayerContext implements Shuffleable {
     }
 
     @Override
-    public void shuffle() {
+    public void skipInt() {
         this.localSeed = SeedMixer.mixSeed(this.localSeed, this.worldSeed);
     }
 }

--- a/src/main/java/net/gegy1000/zoomlayer/mixin/MixinScaleLayer.java
+++ b/src/main/java/net/gegy1000/zoomlayer/mixin/MixinScaleLayer.java
@@ -4,7 +4,7 @@ import net.minecraft.world.biome.layer.ScaleLayer;
 import net.minecraft.world.biome.layer.util.LayerSampleContext;
 import net.minecraft.world.biome.layer.util.LayerSampler;
 
-import net.gegy1000.zoomlayer.Shuffleable;
+import net.gegy1000.zoomlayer.CachingLayerAccess;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
@@ -41,7 +41,7 @@ public abstract class MixinScaleLayer {
         }
 
         // move `choose` into above if-statement: maintain rng parity
-        ((Shuffleable)ctx).shuffle();
+        ((CachingLayerAccess)ctx).skipInt();
 
         if (iz == 0) {
             int tr = parent.sample(this.transformX(x + 1), this.transformZ(z));
@@ -49,7 +49,7 @@ public abstract class MixinScaleLayer {
         }
 
         // move `choose` into above if-statement: maintain rng parity
-        ((Shuffleable)ctx).shuffle();
+        ((CachingLayerAccess)ctx).skipInt();
 
         int bl = parent.sample(this.transformX(x), this.transformZ(z + 1));
         int tr = parent.sample(this.transformX(x + 1), this.transformZ(z));

--- a/src/main/java/net/gegy1000/zoomlayer/mixin/MixinScaleLayer.java
+++ b/src/main/java/net/gegy1000/zoomlayer/mixin/MixinScaleLayer.java
@@ -3,6 +3,8 @@ package net.gegy1000.zoomlayer.mixin;
 import net.minecraft.world.biome.layer.ScaleLayer;
 import net.minecraft.world.biome.layer.util.LayerSampleContext;
 import net.minecraft.world.biome.layer.util.LayerSampler;
+
+import net.gegy1000.zoomlayer.Shuffleable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
@@ -18,6 +20,11 @@ public abstract class MixinScaleLayer {
     @Shadow
     protected abstract int sample(LayerSampleContext<?> ctx, int tl, int tr, int bl, int br);
 
+    /**
+     * Replace with faster implementation.
+     *
+     * @author gegy1000
+     */
     @Overwrite
     public int sample(LayerSampleContext<?> ctx, LayerSampler parent, int x, int z) {
         int tl = parent.sample(this.transformX(x), this.transformZ(z));
@@ -34,7 +41,7 @@ public abstract class MixinScaleLayer {
         }
 
         // move `choose` into above if-statement: maintain rng parity
-        ctx.choose(0, 0);
+        ((Shuffleable)ctx).shuffle();
 
         if (iz == 0) {
             int tr = parent.sample(this.transformX(x + 1), this.transformZ(z));
@@ -42,7 +49,7 @@ public abstract class MixinScaleLayer {
         }
 
         // move `choose` into above if-statement: maintain rng parity
-        ctx.choose(0, 0);
+        ((Shuffleable)ctx).shuffle();
 
         int bl = parent.sample(this.transformX(x), this.transformZ(z + 1));
         int tr = parent.sample(this.transformX(x + 1), this.transformZ(z));


### PR DESCRIPTION
This extracts the mixSeed method out of `nextInt` to remove the overhead of the floorMod.