### PR TITLE
Made ConcurrentLayerCache support 32 bit values

### DIFF
--- a/src/main/java/net/gegy1000/zoomlayer/ConcurrentLayerCache.java
+++ b/src/main/java/net/gegy1000/zoomlayer/ConcurrentLayerCache.java
@@ -19,14 +19,16 @@ import java.util.Arrays;
  * maintained by evicting old entries.
  * <p>
  * Note on key and value sizes:
- * The X and Z components of the keys are limited to 24 bits, and the value is limited to 16 bits. This is such that
- * both together can be packed into a single 64-bit long.
+ * The X and Z components of the keys are limited to 24 bits, and the value is limited to 32 bits.
+ * The value is split into its high 16 bit and its low 16 bit and packed together with the X and Z component
+ * resulting in 2 64-bit longs.
  * <p>
  * Due to Java not having support for value types, without allocating Objects on the heap, it is not possible to store
- * values larger than a long. To store the coordinate key and value at full precision is not be possible within a long.
+ * values larger than a long. To store the coordinate key and value at full precision is not be possible within a single
+ * long.
  * <p>
- * In the case of this cache where it needs to support concurrent access, it is also not possible to split
- * these over a mutable object or multiple arrays due to the possibility for introducing race conditions.
+ * In the case of this cache where it needs to support concurrent access, it is also not possible to separate the keys
+ * from the value pieces over a mutable object or multiple arrays due to the possibility for introducing race conditions.
  */
 public final class ConcurrentLayerCache {
     private static final long KEY_COMP_WIDTH = 24;
@@ -37,7 +39,8 @@ public final class ConcurrentLayerCache {
     private static final long VALUE_WIDTH = 16;
     private static final long VALUE_MASK = (1 << VALUE_WIDTH) - 1;
 
-    private final long[] entries;
+    private final long[] entriesHigh;
+    private final long[] entriesLow;
 
     private final int capacity;
     private final int mask;
@@ -46,15 +49,17 @@ public final class ConcurrentLayerCache {
         this.capacity = MathHelper.smallestEncompassingPowerOfTwo(capacity);
         this.mask = this.capacity - 1;
 
-        this.entries = new long[this.capacity];
-        Arrays.fill(this.entries, Long.MIN_VALUE);
+        this.entriesHigh = new long[this.capacity];
+        Arrays.fill(this.entriesHigh, Long.MIN_VALUE);
+        this.entriesLow = new long[this.capacity];
+        Arrays.fill(this.entriesLow, Long.MIN_VALUE);
     }
 
     /**
      * Retrieves a value from the cache at the given key, or computes and stores the value if it is not already present.
      *
-     * @param x x key
-     * @param z z key
+     * @param x        x key
+     * @param z        z key
      * @param operator operator to compute the value if it is not already cached
      * @return the retrieved or newly computed value
      */
@@ -63,14 +68,16 @@ public final class ConcurrentLayerCache {
         int idx = hash(key) & this.mask;
 
         // if the entry here has a key that matches ours, we have a cache hit
-        long entry = this.entries[idx];
-        if (unpackKey(entry) == key) {
-            return unpackValue(entry);
+        long entryHigh = this.entriesHigh[idx];
+        long entryLow = this.entriesLow[idx];
+        if (unpackKey(entryHigh) == key && unpackKey(entryLow) == key) {
+            return unpackValue(entryHigh) << VALUE_WIDTH | unpackValue(entryLow);
         }
 
         // cache miss: sample the operator and put the result into our cache entry
         int sampled = operator.apply(x, z);
-        this.entries[idx] = pack(key, sampled);
+        this.entriesHigh[idx] = pack(key, sampled >> VALUE_WIDTH);
+        this.entriesLow[idx] = pack(key, sampled & VALUE_MASK);
 
         return sampled;
     }
@@ -87,7 +94,7 @@ public final class ConcurrentLayerCache {
         return (x & KEY_COMP_MASK) << KEY_COMP_WIDTH | z & KEY_COMP_MASK;
     }
 
-    private static long pack(long key, int value) {
+    private static long pack(long key, long value) {
         return (key & KEY_MASK) << VALUE_WIDTH | value & VALUE_MASK;
     }
 


### PR DESCRIPTION
This has been done by converting the entries array into 2 arrays. One of which stores the high 16, the other the low 16.
The value is only returned if both contain the correct key.